### PR TITLE
Support appending a path to host configuration that already have a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.4.0] - 2018-08-29
+### Added
+- Support `host` configurations that already have a path
+
 ## [1.3.0] - 2018-08-29
 ### Added
 - Make defining of `path` in requests optional

--- a/lib/api_client_base/request.rb
+++ b/lib/api_client_base/request.rb
@@ -59,8 +59,12 @@ module APIClientBase
     end
 
     def default_uri
-      uri = URI(host)
-      uri.path = api_client_base_path if !api_client_base_path.nil?
+      uri = if !api_client_base_path.nil?
+              URI.join(host, api_client_base_path)
+            else
+              URI(host)
+            end
+
       uri.to_s
     end
 


### PR DESCRIPTION
This PR contains a change where we can support adding paths on the configured host value that already has a path.