### PR TITLE
Define `before_call` in Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Allow developer to define `before_call` in requests to execute code
+
 ## [1.4.1] - 2019-01-30
 ### Fixed
 - `host` configuration should not remove the path

--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ module MyGem
     def default_action
       :post # defaults to :get
     end
+
+    def before_call
+      # You need not define this, but it might be helpful if you want to log things, for example, before the http request is executed.
+      # The following example would require you to define a `logger` attribute
+
+      self.logger.debug "Will make a #{action} call: #{body}"
+    end
+
   end
 end
 ```

--- a/lib/api_client_base/request.rb
+++ b/lib/api_client_base/request.rb
@@ -32,6 +32,8 @@ module APIClientBase
     end
 
     def call
+      before_call
+
       require "typhoeus"
       if defined?(Typhoeus)
         request = Typhoeus::Request.new(
@@ -85,6 +87,8 @@ module APIClientBase
         new_path.gsub(var, value.to_s)
       end
     end
+
+    def before_call; end
 
   end
 end

--- a/spec/fixtures/cassettes/APIClientBase_Request/_before_call/first_thing_called_in_call_.yml
+++ b/spec/fixtures/cassettes/APIClientBase_Request/_before_call/first_thing_called_in_call_.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://jsonplaceholder.typicode.com/users/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 05:25:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '509'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d6d7b392c151ef371db2f8ae89f0ec4631554269142; expires=Thu, 02-Apr-20
+        05:25:42 GMT; path=/; domain=.typicode.com; HttpOnly
+      X-Powered-By:
+      - Express
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - public, max-age=14400
+      Pragma:
+      - no-cache
+      Expires:
+      - Wed, 03 Apr 2019 09:25:42 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"1fd-+2Y3G3w049iSZtw5t1mzSnunngE"
+      Via:
+      - 1.1 vegur
+      Cf-Cache-Status:
+      - REVALIDATED
+      Accept-Ranges:
+      - bytes
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4c189f999ce4c542-ORD
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": 1,
+          "name": "Leanne Graham",
+          "username": "Bret",
+          "email": "Sincere@april.biz",
+          "address": {
+            "street": "Kulas Light",
+            "suite": "Apt. 556",
+            "city": "Gwenborough",
+            "zipcode": "92998-3874",
+            "geo": {
+              "lat": "-37.3159",
+              "lng": "81.1496"
+            }
+          },
+          "phone": "1-770-736-8031 x56442",
+          "website": "hildegard.org",
+          "company": {
+            "name": "Romaguera-Crona",
+            "catchPhrase": "Multi-layered client-server neural-net",
+            "bs": "harness real-time e-markets"
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 05:25:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/api_client_base/request_spec.rb
+++ b/spec/lib/api_client_base/request_spec.rb
@@ -37,7 +37,7 @@ module APIClientBase
         it "joins the path" do
           request_class = Class.new do
             include APIClientBase::Request.module
-            
+
             def path
               "/moar"
             end

--- a/spec/lib/api_client_base/request_spec.rb
+++ b/spec/lib/api_client_base/request_spec.rb
@@ -67,5 +67,35 @@ module APIClientBase
       end
     end
 
+    describe "#before_call" do
+      it "first thing called in `#call`", vcr: {record: :once} do
+        request_class = Class.new do
+          include APIClientBase::Request.module
+          attribute :before_call_test, String
+          attribute :user_id, Integer
+
+          private
+
+          def path
+            "/users/:user_id"
+          end
+
+          def before_call
+            self.before_call_test = "called"
+          end
+        end
+
+        request = request_class.new({
+          host: "https://jsonplaceholder.typicode.com",
+          user_id: 1,
+        })
+        expect(request.before_call_test).to be_nil
+
+        request.()
+
+        expect(request.before_call_test).to eq "called"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Is useful to do things before http call, like logging.