### PR TITLE
Move http-related code to Request#run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+/.smartgf*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.0
-before_install: gem install bundler -v 1.13.1
+before_install: gem install bundler -v 2.1.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.6.3
 before_install: gem install bundler -v 2.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Move http-related code to Request#run. This is the one that should be overridden, instead of call, since `#call` calls other methods like `before_call`
+
 ## [1.5.0] - 2019-04-03
 ### Added
 - Allow developer to define `before_call` in requests to execute code

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in api_client_base.gemspec
 gemspec
 
-gem "pry-byebug"
+gem "pry-byebug", "~> 3.9"
 gem "typhoeus"

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in api_client_base.gemspec
 gemspec
 
+ruby "2.6.3"
+
 gem "pry-byebug", "~> 3.9"
 gem "typhoeus"

--- a/api_client_base.gemspec
+++ b/api_client_base.gemspec
@@ -34,11 +34,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus", ">= 1.0"
   spec.add_dependency "gem_config", ">= 0.3.1"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "virtus-matchers"
   spec.add_development_dependency "vcr", "~> 3.0"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "dry-validation"
+  spec.add_development_dependency "dry-validation", "< 1.0"
 end

--- a/lib/api_client_base/request.rb
+++ b/lib/api_client_base/request.rb
@@ -33,7 +33,12 @@ module APIClientBase
 
     def call
       before_call
+      run
+    end
 
+    private
+
+    def run
       require "typhoeus"
       if defined?(Typhoeus)
         request = Typhoeus::Request.new(
@@ -46,11 +51,9 @@ module APIClientBase
 
         request.run
       else
-        fail "Either override #call or make sure Typhoeus is available for use."
+        fail "Either override #run or make sure Typhoeus is available for use."
       end
     end
-
-    private
 
     def headers ; {}  ; end
     def body    ; nil ; end

--- a/spec/lib/api_client_base/request_spec.rb
+++ b/spec/lib/api_client_base/request_spec.rb
@@ -97,5 +97,54 @@ module APIClientBase
       end
     end
 
+    describe "#run" do
+      let(:request_class) do
+        Class.new do
+          include APIClientBase::Request.module
+
+          private
+
+          def action
+            "post"
+          end
+
+          def headers
+            {"Content-Type" => "application/json"}
+          end
+
+          def body
+            {"bo" => "deh"}.to_json
+          end
+
+          def params
+            {hi: "there"}
+          end
+
+        end
+      end
+      let(:request) do
+        request_class.new(
+          host: "https://jsonplaceholder.typicode.com",
+        )
+      end
+      let(:typhoeus_request) { instance_double(Typhoeus::Request) }
+
+      it "makes the typhoeus call" do
+        expect(request).to receive(:run).and_call_original
+
+        expect(Typhoeus::Request).to receive(:new).with(
+          "https://jsonplaceholder.typicode.com",
+          method: "post",
+          headers: {"Content-Type" => "application/json"},
+          body: {"bo" => "deh"}.to_json,
+          params: {hi: "there"},
+        ).and_return(typhoeus_request)
+
+        expect(typhoeus_request).to receive(:run)
+
+        request.()
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This is the one that should be overridden, instead of call, since `#call` calls other methods like `before_call`