### PR TITLE
feat: add `after_response` configuration to get access to request and response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- `after_response` hook
+
 ## [1.10.0] - 2021-06-15
 ### Added
 - `dry-validation` 1.x support (0.x support has not been dropped)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ MyGem.configure do |c|
 end
 ```
 
+Note: there is a default configuration setting called `after_response`. See the "Response hooks" section for more details.
+
 - instantiate `MyGem::Client` by calling `MyGem.new(host: "https://api.com", username: "user", password: "password")`. If you do not specify an option, it will use the gem's default.
 
 ### Configuring the `Client`
@@ -241,6 +243,35 @@ end
 ```
 
 You can an example gem [here](https://github.com/bloom-solutions/binance_client-ruby).
+
+#### Response hooks
+
+If you want to give the applications access to the request and response objects after each response (useful when tracking rate limits that are reported in the response, for example), then:
+
+```ruby
+MyGem.configure do |c|
+  c.after_request = ->(request, response) do
+    if response.header("remaining-requets") < 20
+      Rails.logger.warn "mayday!"
+    end
+  end
+end
+```
+
+Note: the request and response objects are the request and response instances such as:
+- `GetUserResponse`
+- `GetUserRequest`
+
+You can assign any object that response to `call`:
+
+```ruby
+class AfterMyGemResponse
+  def self.call(request, response)
+  end
+end
+```
+
+Note: avoid putting long running/expensive requests here because this will block the Ruby process.
 
 ## Development
 

--- a/lib/api_client_base/base.rb
+++ b/lib/api_client_base/base.rb
@@ -21,6 +21,10 @@ module APIClientBase
 
     included do
       include GemConfig::Base
+
+      with_configuration do
+        has :after_response
+      end
     end
 
   end

--- a/lib/api_client_base/client.rb
+++ b/lib/api_client_base/client.rb
@@ -22,6 +22,24 @@ module APIClientBase
     included do
       include APIClientBase::Client::Attributes
       extend APIClientBase::Client::ClassMethods
+
+      private
+
+      def _api_client_call_hook_with(request, response)
+        hook = _api_client_after_response
+        return if hook.nil?
+
+        hook.(request, response)
+      end
+
+      def _api_client_gem_module
+        @_api_client_gem_module ||= self.class.name.deconstantize.constantize
+      end
+
+      def _api_client_after_response
+        return nil if not _api_client_gem_module.respond_to?(:configuration)
+        _api_client_gem_module.configuration.after_response
+      end
     end
 
   end

--- a/lib/api_client_base/client/attributes.rb
+++ b/lib/api_client_base/client/attributes.rb
@@ -10,7 +10,7 @@ module APIClientBase
       private
 
       def self.inherit_attributes!(klass)
-        parent_module = klass.name.deconstantize.constantize
+        parent_module = _api_client_parent_module(klass)
         return unless parent_module.respond_to?(:configuration)
         parent_module.configuration.rules.each do |rule|
           self.inherit_attribute!(klass, rule)
@@ -19,6 +19,10 @@ module APIClientBase
 
       def self.inherit_attribute!(klass, rule)
         klass.attribute rule[0]
+      end
+
+      def self._api_client_parent_module(klass)
+        klass.name.deconstantize.constantize
       end
 
     end

--- a/lib/api_client_base/client/class_methods.rb
+++ b/lib/api_client_base/client/class_methods.rb
@@ -28,7 +28,11 @@ module APIClientBase
 
           request = request_class.new(request_args)
           raw_response = request.()
-          response_class.new(raw_response: raw_response)
+          response = response_class.new(raw_response: raw_response)
+
+          _api_client_call_hook_with request, response
+
+          response
         end
       end
 

--- a/spec/fixtures/cassettes/APIClientBase_Client/after_response_hook/hook_does_not_exist/does_not_blow_up.yml
+++ b/spec/fixtures/cassettes/APIClientBase_Client/after_response_hook/hook_does_not_exist/does_not_blow_up.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jsonplaceholder.typicode.com/posts/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 26 Nov 2021 05:20:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '997'
+      X-Ratelimit-Reset:
+      - '1637544790'
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - max-age=43200
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"116-jnDuMpjju89+9j7e0BqkdFsVRjs"
+      Via:
+      - 1.1 vegur
+      Cf-Cache-Status:
+      - HIT
+      Age:
+      - '12902'
+      Accept-Ranges:
+      - bytes
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=0WmKyRQonuc%2BL1u7Ghxn8gDb5P%2FPFdKQwlSpUBN8WGgJNImTTnGOolw%2FsAGhpgfakVDhxKVtIN5QMkXqt%2F%2BSkY%2F7ZXCAIiFR7BssUNg3oQ5X9qqVhUcfdGJJ8Ys%2BZUAFxe3Tt5ZZSosTf14iqlGKnWnBb6qcwDgdkfn4"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6b40ab98c9a53c5e-HKG
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400, h3-28=":443"; ma=86400, h3-27=":443";
+        ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "userId": 1,
+          "id": 2,
+          "title": "qui est esse",
+          "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
+        }
+    http_version:
+  recorded_at: Fri, 26 Nov 2021 05:20:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/APIClientBase_Client/after_response_hook/hook_responding_to_call_exists/is_called.yml
+++ b/spec/fixtures/cassettes/APIClientBase_Client/after_response_hook/hook_responding_to_call_exists/is_called.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jsonplaceholder.typicode.com/posts/2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 26 Nov 2021 05:02:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '997'
+      X-Ratelimit-Reset:
+      - '1637544790'
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - max-age=43200
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"116-jnDuMpjju89+9j7e0BqkdFsVRjs"
+      Via:
+      - 1.1 vegur
+      Cf-Cache-Status:
+      - HIT
+      Age:
+      - '11769'
+      Accept-Ranges:
+      - bytes
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=iEnXyceyPFb4uPsRi3UMMMzanJ6SZwyuZpXKn5ByWL55RDe%2F6mwAW8U5eJF4%2F0ddtSAvggE52%2F7IVrirvtF0qfidFKAEGJOM8C38dKAge1py1YFIS3wnhuRe3ejtKesHQ%2FvqAoZxzB4CgM963eIbmv7RTcubhTtQRt0%2F"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6b408ff1c8036e3a-HKG
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400, h3-28=":443"; ma=86400, h3-27=":443";
+        ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "userId": 1,
+          "id": 2,
+          "title": "qui est esse",
+          "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
+        }
+    http_version:
+  recorded_at: Fri, 26 Nov 2021 05:02:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/api_client_base/base_spec.rb
+++ b/spec/lib/api_client_base/base_spec.rb
@@ -43,5 +43,16 @@ module APIClientBase
       expect(client.password).to be_nil
     end
 
+    it "allows setting of `after_response`" do
+      hook = Class.new do
+        def self.call(request, response)
+        end
+      end
+
+      GemTestBase.configuration.after_response = hook
+
+      expect(GemTestBase.configuration.after_response).to eq hook
+    end
+
   end
 end


### PR DESCRIPTION
This is run after a response is completed, right before returning the response