### PR TITLE
feat: Add `#headers` and `#header(key)` methods to response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - `after_response` hook
+- Add `#headers` and `#header(key)` methods to response for easy access to the headers
 
 ## [1.10.0] - 2021-06-15
 ### Added

--- a/lib/api_client_base/response.rb
+++ b/lib/api_client_base/response.rb
@@ -26,6 +26,7 @@ module APIClientBase
       attribute :success, self::Boolean, lazy: true, default: :default_success
       attribute :code, Integer, lazy: true, default: :default_code
       attribute :body, String, lazy: true, default: :default_body
+      attribute :headers, Hash, lazy: true, default: :default_headers
     end
 
     def default_success
@@ -38,6 +39,14 @@ module APIClientBase
 
     def default_body
       raw_response.body
+    end
+
+    def default_headers
+      (raw_response.headers || {}).transform_keys {|key| key.upcase }
+    end
+
+    def header(key)
+      headers[key.upcase]
     end
 
   end

--- a/spec/lib/api_client_base/response_spec.rb
+++ b/spec/lib/api_client_base/response_spec.rb
@@ -15,6 +15,63 @@ module APIClientBase
       it { is_expected.to have_attribute(:code, Integer) }
     end
 
+    describe "#headers" do
+      let(:response_class) do
+        Class.new do
+          include APIClientBase::Response.module
+        end
+      end
+      let(:headers) do
+        { "CONTENT-TYPE" => "application/json" }
+      end
+      let(:raw_response) do
+        instance_double(Typhoeus::Response, headers: headers)
+      end
+      let(:response) { response_class.new(raw_response: raw_response) }
+
+      it "gives access to the headers hash" do
+        expect(response.headers).to eq headers
+      end
+    end
+
+    describe "#header" do
+      let(:response_class) do
+        Class.new do
+          include APIClientBase::Response.module
+        end
+      end
+      let(:raw_response) do
+        instance_double(Typhoeus::Response, headers: headers)
+      end
+      let(:response) { response_class.new(raw_response: raw_response) }
+
+      context "headers is nil" do
+        let(:headers) { nil }
+        subject { response.header("Content-Type") }
+        it { is_expected.to be_nil }
+      end
+
+      context "headers exist but no key" do
+        let(:headers) { {} }
+        subject { response.header("Content-Type") }
+        it { is_expected.to be_nil }
+      end
+
+      context "header exists" do
+        let(:headers) { {"Content-Type" => "application/json"} }
+
+        context "exact match" do
+          subject { response.header("Content-Type") }
+          it { is_expected.to eq "application/json" }
+        end
+
+        context "different case" do
+          subject { response.header("content-type") }
+          it { is_expected.to eq "application/json" }
+        end
+      end
+    end
+
     describe "#success?" do
       let(:response_class) do
         Class.new do


### PR DESCRIPTION
for easy access to the headers